### PR TITLE
Fixed null object in Dump-StoreWorkerOnFailureItem

### DIFF
--- a/Dump-StoreWorkerOnFailureItem/Dump-StoreWorkerOnFailureItem.ps1
+++ b/Dump-StoreWorkerOnFailureItem/Dump-StoreWorkerOnFailureItem.ps1
@@ -42,7 +42,7 @@ while ($true)
         $doc = [xml]$event.ToXml()
         $tag = $doc.Event.UserData.EventXML.Tag
         $dbGuid = $doc.Event.UserData.EventXML.DatabaseGuid.Trim(@('{', '}')).ToUpper()
-        if (!($tags.Contains($tag)))
+        if (!($dumpOnTags.Contains($tag)))
         {
             "Ignoring failure item with tag: " + $tag
             continue


### PR DESCRIPTION
$tags is never defined, therefore we can never call .Contains on it. Looks like it should have been called $dumpOnTags